### PR TITLE
Added missing requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "contao/core-bundle": "^5.3"
+        "contao/core-bundle": "^5.3",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1"

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "cubex-hro/contao-openai-bundle",
     "type": "contao-bundle",
     "license": "MIT",
+    "version": "1.1.2",
     "description": "enables the generation of meta-title and meta-descriptions in the backend of Contao using ChatGPT from OpenAi",
     "authors": [
         {


### PR DESCRIPTION
this addresses the following error on a fresh C5.3 installation:
[2024-06-12T21:31:28.378677+00:00] request.CRITICAL: Uncaught PHP Exception Error: "Class "GuzzleHttp\Client" not found" at GptController.php line 106 {"exception":"[object] (Error(code: 0): Class \"GuzzleHttp\\Client\" not found at /var/www/html/repos/contao-openai-bundle/src/Controller/GptController.php:106)"} {"request_uri":"https://c53.ddev.site:8443/_gpt?id=2&mode=title","request_method":"GET"}